### PR TITLE
capabilities ERANG error fix

### DIFF
--- a/hostapd/Android.mk
+++ b/hostapd/Android.mk
@@ -33,6 +33,10 @@ ifeq ($(BOARD_HOSTAPD_PRIVATE_LIB),)
 L_CFLAGS += -DANDROID_P2P_STUB
 endif
 
+ifeq ($(BOARD_WIFI_SKIP_CAPABILITIES), true)
+L_CFLAGS += -DBOARD_WIFI_SKIP_CAPABILITIES
+endif
+
 # Use Android specific directory for control interface sockets
 L_CFLAGS += -DCONFIG_CTRL_IFACE_CLIENT_DIR=\"/data/misc/wifi/sockets\"
 L_CFLAGS += -DCONFIG_CTRL_IFACE_DIR=\"/data/system/hostapd\"

--- a/src/drivers/driver_nl80211.c
+++ b/src/drivers/driver_nl80211.c
@@ -7723,7 +7723,9 @@ static int wpa_driver_nl80211_sta_add(void *priv,
 			   params->listen_interval);
 		NLA_PUT_U16(msg, NL80211_ATTR_STA_LISTEN_INTERVAL,
 			    params->listen_interval);
-	} else if (params->aid && (params->flags & WPA_STA_TDLS_PEER)) {
+	}
+#ifndef BOARD_WIFI_SKIP_CAPABILITIES
+	else if (params->aid && (params->flags & WPA_STA_TDLS_PEER)) {
 		wpa_printf(MSG_DEBUG, "  * peer_aid=%u", params->aid);
 		NLA_PUT_U16(msg, NL80211_ATTR_PEER_AID, params->aid);
 	}
@@ -7761,6 +7763,7 @@ static int wpa_driver_nl80211_sta_add(void *priv,
 			params->ext_capab_len, params->ext_capab);
 	}
 
+#endif
 	if (params->supp_channels) {
 		wpa_hexdump(MSG_DEBUG, "  * supported channels",
 			    params->supp_channels, params->supp_channels_len);


### PR DESCRIPTION
Add BOARD_WIFI_SKIP_CAPABILITIES flag to skip this portion of
driver setup.  Looks like it's not supported in 3.0 and 3.4 kernel

Change-Id: Id750f8f648a62e0c27a2c4597a3a9a46a349f95f
